### PR TITLE
"File used by other process" error fix

### DIFF
--- a/lib/paperclip-compression/jpeg.rb
+++ b/lib/paperclip-compression/jpeg.rb
@@ -18,7 +18,10 @@ module PaperclipCompression
     def make
       begin
         if @cli_opts
+          #  close dst file, so jpegtran can write it
+          @dst.close
           Paperclip.run(command_path('jpegtran'), "#{@cli_opts} :src_path > :dst_path", src_path: @src_path, dst_path: @dst_path)
+          @dst.open
           @dst
         else
           @file


### PR DESCRIPTION
I was receiving "The process cannot access the file because it is being used by another process" error on windows. This fix closes tempfile so jpegtran can write it, reopens just after it. Tempfile.close doesnt unlink file, just releases the handle ( http://ruby-doc.org/stdlib-1.9.3/libdoc/tempfile/rdoc/Tempfile.html )