### PR TITLE
Remove ruby-imagespec dependency

### DIFF
--- a/lib/paperclip-compression.rb
+++ b/lib/paperclip-compression.rb
@@ -1,6 +1,5 @@
 require 'paperclip'
 require 'os'
-require 'image_spec'
 require 'paperclip-compression/paperclip/compression'
 require 'paperclip-compression/base'
 require 'paperclip-compression/jpeg'

--- a/lib/paperclip-compression/paperclip/compression.rb
+++ b/lib/paperclip-compression/paperclip/compression.rb
@@ -22,7 +22,7 @@ module Paperclip
     end
 
     def content_type
-      @file.is_a?(Paperclip::AbstractAdapter) ? @file.content_type : ImageSpec.new(@file).content_type
+      @file.is_a?(Paperclip::AbstractAdapter) ? @file.content_type : Paperclip::ContentTypeDetector.new(@file.path).detect
     end
 
   end

--- a/paperclip-compression.gemspec
+++ b/paperclip-compression.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'paperclip', ['>= 4.2.2']
   s.add_runtime_dependency 'os', ['~> 0.9.6']
-  s.add_runtime_dependency 'ruby-imagespec', ['~> 0.4.1']
 
   s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'rake', '~> 10.1'


### PR DESCRIPTION
Remove ruby-imagespec gem and rely on Paperclip::ContentTypeDetector class for content detection when processing Tempfiles.