### PR TITLE
For accurate file info, re-open output file after compressing

### DIFF
--- a/lib/paperclip-compression/base.rb
+++ b/lib/paperclip-compression/base.rb
@@ -17,6 +17,28 @@ module PaperclipCompression
       new(file, first_processor, options).make
     end
 
+    def process_file
+      # Close output file so compressors which require exclusive file rights
+      # work.
+      @dst.close
+
+      # Execute the child-compressor classes implementation of how to compress
+      # the output
+      compress
+
+      # Re-open the output file so downstream paperclip-middleware may
+      # read/write/etc. without having to re-open the file.
+      @dst.open
+
+      # Return the destination file for downstream paperclip processors.
+      @dst
+    end
+
+    private def compress
+      fail MustImplementInSubClassesException,
+           'compress is overridden on a per compressor basis.'
+    end
+
     protected
 
     def process_file?
@@ -73,4 +95,7 @@ module PaperclipCompression
       FileUtils.cp(@src_path, @dst_path)
     end
   end
+
+  # Informs developers when a method is intended to be defined in # sub-classes.
+  class MustImplementInSubClassesException < Exception; end
 end

--- a/lib/paperclip-compression/jpeg.rb
+++ b/lib/paperclip-compression/jpeg.rb
@@ -24,12 +24,10 @@ module PaperclipCompression
       JPEGTRAN_DEFAULT_OPTS
     end
 
-    def process_file
-      # close dst file, so jpegtran can write it
-      @dst.close
-      Paperclip.run(command_path('jpegtran'), "#{@cli_opts} :src_path > :dst_path", src_path: @src_path, dst_path: @dst_path)
-      @dst.open
-      @dst
+    def compress
+      Paperclip.run(command_path('jpegtran'),
+                    "#{@cli_opts} :src_path > :dst_path",
+                    src_path: @src_path, dst_path: @dst_path)
     end
   end
 end

--- a/lib/paperclip-compression/png.rb
+++ b/lib/paperclip-compression/png.rb
@@ -24,10 +24,10 @@ module PaperclipCompression
       OPTIPNG_DEFAULT_OPTS
     end
 
-    def process_file
-      Paperclip.run(command_path('optipng'), "#{@cli_opts} -clobber :src_path -out :dst_path", src_path: @src_path, dst_path: @dst_path)
-      @dst
+    def compress
+      Paperclip.run(command_path('optipng'),
+                    "#{@cli_opts} -clobber :src_path -out :dst_path",
+                    src_path: @src_path, dst_path: @dst_path)
     end
-
   end
 end


### PR DESCRIPTION
Fixes #16

- Promoted `process_file` to `Base`
  - Created a seam via the `compress` method
  - Introduced a `MustBeImplementedInSubClassesException` so we don't
    forget to define compress in the future.
  - Shifted responsibility of closing/opening file to `Base#process_file`
- Split the body of `compress` into multiple lines for readability
  purposes